### PR TITLE
Fix reset button not clearing race progress

### DIFF
--- a/sql_grand_prix_single_file_html_classroom_game.html
+++ b/sql_grand_prix_single_file_html_classroom_game.html
@@ -879,11 +879,21 @@ Question: Say the titles that match (max 3).`,
   els.stepWrong.addEventListener('input', e=>{state.step.wrong=parseInt(e.target.value||'-5',10);save()});
 
   els.undo.addEventListener('click', undo);
+  els.reset.addEventListener('click', resetRace);
   function undo(){
     const last = state.history.pop();
     if(!last) return;
     const snap = JSON.parse(last);
     state.teams = snap.teams; save(); render();
+  }
+  function resetRace(){
+    if(!confirm('Reset all scores?')) return;
+    state.history = [];
+    state.teams = state.teams.map(t=>({...t, pct:0}));
+    save();
+    render();
+    if(els.winner) els.winner.classList.remove('show');
+    if(els.confetti) els.confetti.innerHTML='';
   }
   document.addEventListener('keydown', (e)=>{
     const k = e.key;


### PR DESCRIPTION
## Summary
- Wire up Reset Race button to clear team scores and history
- Hide winner overlay and confetti when resetting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b49c15883338e0fbeecda4b4a4c